### PR TITLE
Fix slight music stutter when swapping between 2 charts with the same song

### DIFF
--- a/src/Audio/Audio.fs
+++ b/src/Audio/Audio.fs
@@ -95,11 +95,12 @@ module Song =
         timer.Start()
 
     let changeRate(newRate) =
+        let didRateChange = rate <> newRate
         let time = time()
         rate <- newRate
         //if (true) then Bass.ChannelSetAttribute(nowplaying.ID, ChannelAttribute.Pitch, -Math.Log(float rate, 2.0) * 12.0) |> bassError
         Bass.ChannelSetAttribute(nowplaying.ID, ChannelAttribute.Frequency, float32 nowplaying.Frequency * rate) |> bassError
-        seek time
+        if didRateChange then seek time
 
     let changeLocalOffset(offset) = localOffset <- offset
     let changeGlobalOffset(offset) = globalOffset <- offset

--- a/src/Audio/Audio.fs
+++ b/src/Audio/Audio.fs
@@ -76,15 +76,11 @@ module Song =
     let playLeadIn() = playFrom(-LEADIN_TIME * rate)
 
     let seek(time) =
-        if (time >= 0.0f<ms> && time < duration()) then
-            if playing() then playFrom time
-            else
-                Bass.ChannelSetPosition(nowplaying.ID, Bass.ChannelSeconds2Bytes(nowplaying.ID, float <| time / 1000.0f<ms>)) |> bassError
-                timer.Reset()
-                timerStart <- time
-        elif timer.IsRunning then 
+        if playing() then
             playFrom time
-        else 
+        else
+            if (time >= 0.0f<ms> && time < duration()) then
+                Bass.ChannelSetPosition(nowplaying.ID, Bass.ChannelSeconds2Bytes(nowplaying.ID, float <| time / 1000.0f<ms>)) |> bassError
             timer.Reset()
             timerStart <- time
 


### PR DESCRIPTION
The if statement simplification is unrelated, it just annoyed me there was a direct and then indirect way to check `playing()` that did the same thing anyways
changing songs still get the adjusted rate thanks to the song_loader.Handle indiscriminate call to changeRate